### PR TITLE
Ajusta a comparação de datas para garantir que ambas tenham fuso horário

### DIFF
--- a/checker/check_ssl.py
+++ b/checker/check_ssl.py
@@ -1,6 +1,7 @@
 import ssl
 import socket
 from urllib.parse import urlparse
+from datetime import datetime, timezone
 
 def check_ssl(url):
     parsed_url = urlparse(url)
@@ -8,16 +9,31 @@ def check_ssl(url):
 
     if ":" in hostname:
         hostname = hostname.split(":")[0]
+    
     try:
         context = ssl.create_default_context()
+        
         with socket.create_connection((hostname, 443), timeout=5) as sock:
             with context.wrap_socket(sock, server_hostname=hostname) as ssock:
                 cert = ssock.getpeercert()
-        expiry_date = ssl.cert_time_to_seconds(cert['notAfter'])
-        days_remaining = (expiry_date - ssl.cert_time_to_seconds(cert['notBefore'])) / (60 * 60 * 24)
+        
+        not_before = cert['notBefore']
+        not_after = cert['notAfter']
+        
+        not_before_date = datetime.strptime(not_before, "%b %d %H:%M:%S %Y GMT")
+        not_after_date = datetime.strptime(not_after, "%b %d %H:%M:%S %Y GMT")
+        
+        not_before_date = not_before_date.replace(tzinfo=timezone.utc)  # Torna o datetime "aware"
+        not_after_date = not_after_date.replace(tzinfo=timezone.utc)    # Torna o datetime "aware"
+        
+        validity_days = (not_after_date - not_before_date).days
+        days_remaining = (not_after_date - datetime.now(timezone.utc)).days
+        
+        print(f"Validade do certificado: {validity_days} dias")
         return days_remaining > 0
+    
     except Exception as e:
+        print(f"Erro ao verificar SSL: {e}")
         return False
 
-print(check_ssl("https://example.com"))
-
+#print (check_ssl("https://www.google.com"))


### PR DESCRIPTION
Torna `not_before_date` e `not_after_date` cientes de fuso horário usando UTC, pra evitar erro ao comparar datas sem e com fuso horário.







